### PR TITLE
Fix missing type annotations for Gemini API compatibility

### DIFF
--- a/server.py
+++ b/server.py
@@ -9,8 +9,8 @@ mcp = FastMCP("gnomAD MCP Server")
 def get_gene_info(
     gene_id: Optional[str] = None,
     gene_symbol: Optional[str] = None,
-    dataset = 'gnomad_r4',
-    reference_genome = 'GRCh38'
+    dataset: str = 'gnomad_r4',
+    reference_genome: str = 'GRCh38'
 ) -> dict:
     """
     [gnomAD API] Retrieve gene information (v4 only)
@@ -67,7 +67,7 @@ def get_region_info(
     chrom: str,
     start: int,
     stop: int,
-    dataset = 'gnomad_r4'
+    dataset: str = 'gnomad_r4'
 ) -> dict:
     """
     [gnomAD API] Retrieve region information (v4 only)
@@ -147,7 +147,7 @@ def get_clinvar_variant_info(
 def get_mitochondrial_variant_info(
     reference_genome: str,
     variant_id: str,
-    dataset = 'gnomad_r4'
+    dataset: str = 'gnomad_r4'
 ) -> dict:
     """
     [gnomAD API] Retrieve mitochondrial variant info (v4 only)
@@ -199,7 +199,7 @@ def get_structural_variant_info(
 def get_copy_number_variant_info(
     reference_genome: str,
     variantId: str,
-    dataset = 'gnomad_cnv_r4'
+    dataset: str = 'gnomad_cnv_r4'
 ) -> dict:
     """
     [gnomAD API] Retrieve copy number variant info (v4 only)
@@ -250,7 +250,7 @@ def search_for_variants(
 def get_str_info(
     reference_genome: str,
     id: str,
-    dataset = 'gnomad_r4'
+    dataset: str = 'gnomad_r4'
 ) -> dict:
     """
     [gnomAD API] Retrieve STR info (v4 only)
@@ -279,7 +279,7 @@ def get_variant_liftover(
     reference_genome: str,
     source_variant_id: Optional[str] = None,
     liftover_variant_id: Optional[str] = None,
-    dataset = 'gnomad_r2_1'
+    dataset: str = 'gnomad_r2_1'
 ) -> dict:
     """
     [gnomAD API] Retrieve liftover info (v2 only)


### PR DESCRIPTION
  ## Fix missing type annotations for Gemini API
  compatibility

  ### Problem
  When using this MCP server with Google Gemini API,
   function calls fail with:
  **Unable to submit request because gnomad__get_gene_info functionDeclaration parameters.dataset schema didn't specify the schema type field**

  ### Root Cause
  Function parameters like `dataset = 'gnomad_r4'` lack explicit type annotations, so FastMCP cannot generate proper JSON schemas with required `type` fields.

  ### Solution
  Added explicit type annotations: `dataset: str = 'gnomad_r4'`

  ### Functions Fixed
  - `get_gene_info`
  - `get_region_info`
  - `get_mitochondrial_variant_info`
  - `get_copy_number_variant_info`
  - `get_str_info`
  - `get_variant_liftover`

  ### Testing
  ✅ Verified gnomad functions now work with Google
  Gemini API